### PR TITLE
Acceptance tests

### DIFF
--- a/CallPolly.sln
+++ b/CallPolly.sln
@@ -11,10 +11,11 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "CallPolly.Tests", "tests\Ca
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Newtonsoft.Json.Converters.FSharp", "src\Newtonsoft.Json.Converters.FSharp\Newtonsoft.Json.Converters.FSharp.fsproj", "{CBC2F73D-BEB8-4775-8FCD-A48083C5E900}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6047ADD6-C48C-4583-A5C6-58FDF7A0DC10}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".project", ".project", "{6047ADD6-C48C-4583-A5C6-58FDF7A0DC10}"
 	ProjectSection(SolutionItems) = preProject
 		LICENSE = LICENSE
 		README.md = README.md
+		SECURITY.md = SECURITY.md
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # CallPolly
 
-[Polly](https://github.com/App-vNext/Polly) is a focused library _and a rich set of documentation, samples and discussions_ around various resilience patterns for .NET.
+[_Polly_](https://github.com/App-vNext/Polly) is a focused library _and a rich set of documentation, samples and discussions_ around various resilience patterns for .NET.
 
 Look no further for a mature, well thought out set of abstractions with a responsive community.
 
 ----
 
-**_Presently under heavy development, please excuse the lack of roadmap or proper examples for bit._**
+**_All this is presently under heavy development, please excuse the lack of roadmap for a bit longer..._**
 
-CallPolly wraps Polly to provide a:
+CallPolly wraps Polly to provide:
 - parsing and validation of a suite of rules in a declarative form (presently json, but being able to maintain the inputs in YAML is on the wishlist)
 - a ruleset interpreter that applies the rules in a consistent fashion
 
@@ -16,3 +16,59 @@ Using CallPolly will _eventually_ enable one to:
 - wrap calls with minimal invasive code changes
 - use [Open Tracing](http://opentracing.io/)-based Distributed Tracing systems and dashboards to analyze the effects of the configured Call Policy as applied
 - iteratively adjust those policies across a set of systems
+
+## Taster: example policy
+
+See the [acceptance tests](https://github.com/jet/CallPolly/blob/master/tests/CallPolly.Acceptance/Orchestration.fs#L142) for behavior implied by this configuration:
+```
+{ "services": {
+
+"ingres": {
+    "calls": {
+        "api-a": "quick",
+        "api-b": "slow"
+    },
+    "defaultPolicy": null,
+    "policies": {
+        "quick": [
+            { "rule": "Cutoff",     "timeoutMs": 1000, "slaMs": 500 }
+        ],
+        "slow": [
+            { "rule": "Cutoff",     "timeoutMs": 10000, "slaMs": 5000 }
+        ]
+    }
+},
+"upstreamA": {
+    "calls": {
+        "Call1": "looser",
+        "Call2": "default",
+        "CallBroken": "defaultBroken"
+    },
+    "defaultPolicy": null,
+    "policies": {
+        "default": [
+            { "rule": "Limit",      "maxParallel": 10, "maxQueue": 3 }
+        ],
+        "looser": [
+            { "rule": "Limit",      "maxParallel": 100, "maxQueue": 300 }
+        ],
+        "defaultBroken": [
+            { "rule": "Isolate" }
+        ]
+    }
+},
+"upstreamB": {
+    "calls": {
+        "Call1": "default",
+    },
+    "defaultPolicy": null,
+    "policies": {
+        "default": [
+            { "rule": "Limit",      "maxParallel": 2, "maxQueue": 8 },
+            { "rule": "Break",      "windowS": 5, "minRequests": 10, "failPct": 20, "breakS": 1 }
+        ]
+    }
+}
+
+}
+```

--- a/src/CallPolly/Rules.fs
+++ b/src/CallPolly/Rules.fs
@@ -98,8 +98,11 @@ type Governor(log: Serilog.ILogger, serviceName: string, callName : string, poli
             log |> Events.Log.actionIsolated (serviceName, callName, policyName)
             None
         | :? Polly.CircuitBreaker.BrokenCircuitException ->
-            let c = config.breaker.Value
-            let config : Events.BreakerParams = { window = c.window; minThroughput = c.minThroughput; errorRateThreshold = c.errorRateThreshold }
+            let config : Events.BreakerParams =
+                // TODO figure out why/how this can happen
+                match config.breaker with
+                | Some c -> { window = c.window; minThroughput = c.minThroughput; errorRateThreshold = c.errorRateThreshold }
+                | None -> Unchecked.defaultof<_>
             log |> Events.Log.actionBroken (serviceName, callName, policyName) config
             None
         | :? Polly.Timeout.TimeoutRejectedException ->

--- a/tests/CallPolly.Acceptance/CallPolly.Acceptance.fsproj
+++ b/tests/CallPolly.Acceptance/CallPolly.Acceptance.fsproj
@@ -7,13 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Tests.fs" />
+    <Compile Include="..\CallPolly.Tests\Infrastructure.fs" Link="Infrastructure.fs" />
+    <Compile Include="Orchestration.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+    <PackageReference Include="Unquote" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/tests/CallPolly.Acceptance/Orchestration.fs
+++ b/tests/CallPolly.Acceptance/Orchestration.fs
@@ -1,0 +1,135 @@
+﻿module CallPolly.Acceptance.Tests
+
+open CallPolly
+open Swensen.Unquote
+open System
+open Xunit
+
+[<AutoOpen>]
+module Helpers =
+    let ms x = TimeSpan.FromMilliseconds (float x)
+    let s x = TimeSpan.FromSeconds (float x)
+    let between min max (value : float) = value >= min && value <= max
+
+let policy = """
+{
+    "services": {
+        "ingres": {
+            "calls": {
+                "api-a": "quick",
+                "api-b": "slow"
+            },
+            "defaultPolicy": null,
+            "policies": {
+                "quick": [
+                    { "rule": "Cutoff",     "timeoutMs": 1000, "slaMs": 500 }
+                ],
+                "slow": [
+                    { "rule": "Cutoff",     "timeoutMs": 10000, "slaMs": 5000 }
+                ]
+            }
+        },
+        "upstreamA": {
+            "calls": {
+                "Call1": "default",
+                "Call2": "default",
+                "CallBroken": "defaultBroken"
+            },
+            "defaultPolicy": null,
+            "policies": {
+                "default": [
+                    { "rule": "Limit",      "maxParallel": 1, "maxQueue": 3 }
+                ],
+                "defaultBroken": [
+                    { "rule": "Isolate" }
+                ]
+            }
+        },
+        "upstreamB": {
+            "calls": {
+                "Call1": "default",
+            },
+            "defaultPolicy": null,
+            "policies": {
+                "default": [
+                    { "rule": "Limit",      "maxParallel": 2, "maxQueue": 0 },
+                    { "rule": "Break",      "windowS": 5, "minRequests": 10, "failPct": 20, "breakS": 1 }
+                ]
+            }
+        }
+    }
+}
+"""
+
+type Act =
+    | Succeed
+    | ThrowTimeout
+    | DelayMs of ms:int
+    | DelayS of s:int
+    member this.Execute() = async {
+        match this with
+        | Succeed ->    return 42
+        | ThrowTimeout -> return raise <| TimeoutException()
+        | DelayMs x ->  do! Async.Sleep(ms x)
+                        return 43
+        | DelayS x ->   do! Async.Sleep(s x)
+                        return 43 }
+
+type Sut(log : Serilog.ILogger, policy: CallPolly.Rules.Policy<_,_>) =
+
+    let run serviceName callName f = policy.Find(serviceName, callName).Execute(f)
+
+    let _upstreamA1 (a : Act) =
+        log.Information("A1")
+        a.Execute()
+    let upstreamA1 d = run "upstreamA" "Call1" <| _upstreamA1 d
+
+    let _upstreamA2 (a : Act) =
+        log.Information("A2")
+        a.Execute()
+    let upstreamA2 d = run "upstreamA" "Call2" <| _upstreamA2 d
+
+    let _upstreamA3 (a : Act) =
+        log.Information("A3")
+        a.Execute()
+    let upstreamA3 d = run "upstreamA" "CallBroken" <| _upstreamA3 d
+
+    let _upstreamB1 (a : Act) =
+        log.Information("B1")
+        a.Execute()
+    let upstreamB1 d = run "upstreamB" "Call1" <| _upstreamB1 d
+
+    let _apiA a1 a2 = async {
+        let! a = upstreamA1 a1
+        let! b = upstreamA2 a2
+        return a + b
+    }
+
+    let _apiBroken = upstreamA3 Succeed
+
+    let _apiB b1 = upstreamB1 b1
+    member __.ApiQuick a1 a2 = run "ingres" "api-a" <| _apiA a1 a2
+    member __.ApiSlow b1 = run "ingres" "api-b" <| _apiB b1
+
+let (|Http200|Http500|Http503|Http504|) : Choice<int,exn> -> _ = function
+    | Choice1Of2 _ -> Http200
+    | Choice2Of2 (:? Polly.ExecutionRejectedException) -> Http503
+    | Choice2Of2 (:? TimeoutException) -> Http504
+    | Choice2Of2 _ -> Http500
+
+let (|Status|) : Choice<int,exn> -> int = function
+    | Http200 -> 200
+    | Http500 -> 500
+    | Http503 -> 503
+    | Http504 -> 504
+
+/// Acceptance tests illustrating the indended use of CallPolly wrt implementing flow control within an orchestration layer
+type Orchestration(output : Xunit.Abstractions.ITestOutputHelper) =
+    let log = LogHooks.createLogger output
+
+    let [<Fact>] ``Cutoff can be used to cap call time when upstreams misbehave`` () = async {
+        let policy = Parser.parse log policy
+        let sut = Sut(log, policy)
+        let! time, (Status res) = sut.ApiQuick Succeed (DelayS 5) |> Async.Catch |> Stopwatch.Time
+        test <@ res = 503 && between 1. 1.2 (time.Elapsed.TotalSeconds) @>
+    }

--- a/tests/CallPolly.Acceptance/Orchestration.fs
+++ b/tests/CallPolly.Acceptance/Orchestration.fs
@@ -11,6 +11,12 @@ module Helpers =
     let s x = TimeSpan.FromSeconds (float x)
     let between min max (value : float) = value >= min && value <= max
 
+type SerilogHelpers.LogCaptureBuffer with
+    member buffer.Take() =
+        let actual = [for x in buffer.Entries -> x.RenderMessage()]
+        buffer.Clear()
+        actual
+
 let policy = """
 {
     "services": {
@@ -52,7 +58,7 @@ let policy = """
             "defaultPolicy": null,
             "policies": {
                 "default": [
-                    { "rule": "Limit",      "maxParallel": 2, "maxQueue": 0 },
+                    { "rule": "Limit",      "maxParallel": 2, "maxQueue": 8 },
                     { "rule": "Break",      "windowS": 5, "minRequests": 10, "failPct": 20, "breakS": 1 }
                 ]
             }
@@ -66,48 +72,54 @@ type Act =
     | ThrowTimeout
     | DelayMs of ms:int
     | DelayS of s:int
+    | Composite of Act list
     member this.Execute() = async {
         match this with
-        | Succeed ->    return 42
-        | ThrowTimeout -> return raise <| TimeoutException()
-        | DelayMs x ->  do! Async.Sleep(ms x)
-                        return 43
-        | DelayS x ->   do! Async.Sleep(s x)
-                        return 43 }
+        | Succeed ->        return 42
+        | ThrowTimeout ->   return raise <| TimeoutException()
+        | DelayMs x ->      do! Async.Sleep(ms x)
+                            return 43
+        | DelayS x ->       do! Async.Sleep(s x)
+                            return 43
+        | Composite xs ->   for x in xs do
+                                do! x.Execute() |> Async.Ignore
+                            return 43}
 
 type Sut(log : Serilog.ILogger, policy: CallPolly.Rules.Policy<_,_>) =
 
     let run serviceName callName f = policy.Find(serviceName, callName).Execute(f)
 
-    let _upstreamA1 (a : Act) =
+    let _upstreamA1 (a : Act) = async {
         log.Information("A1")
-        a.Execute()
-    let upstreamA1 d = run "upstreamA" "Call1" <| _upstreamA1 d
+        return! a.Execute() }
+    let upstreamA1 a = run "upstreamA" "Call1" <| _upstreamA1 a
 
-    let _upstreamA2 (a : Act) =
+    let _upstreamA2 (a : Act) = async {
         log.Information("A2")
-        a.Execute()
-    let upstreamA2 d = run "upstreamA" "Call2" <| _upstreamA2 d
+        return! a.Execute() }
+    let upstreamA2 a = run "upstreamA" "Call2" <| _upstreamA2 a
 
-    let _upstreamA3 (a : Act) =
+    let _upstreamA3 (a : Act) = async {
         log.Information("A3")
-        a.Execute()
-    let upstreamA3 d = run "upstreamA" "CallBroken" <| _upstreamA3 d
+        return! a.Execute() }
+    let upstreamA3 a = run "upstreamA" "CallBroken" <| _upstreamA3 a
 
-    let _upstreamB1 (a : Act) =
+    let _upstreamB1 (a : Act) = async {
         log.Information("B1")
-        a.Execute()
-    let upstreamB1 d = run "upstreamB" "Call1" <| _upstreamB1 d
+        return! a.Execute() }
+    let upstreamB1 a = run "upstreamB" "Call1" <| _upstreamB1 a
 
     let _apiA a1 a2 = async {
+        log.Information "ApiA"
         let! a = upstreamA1 a1
         let! b = upstreamA2 a2
         return a + b
     }
-
+    let _apiB b1 = async {
+        log.Information "ApiB"
+        return! upstreamB1 b1
+    }
     let _apiBroken = upstreamA3 Succeed
-
-    let _apiB b1 = upstreamB1 b1
     member __.ApiOneSecondSla a1 a2 = run "ingres" "api-a" <| _apiA a1 a2
     member __.ApiTenSecondSla b1 = run "ingres" "api-b" <| _apiB b1
 
@@ -125,7 +137,7 @@ let (|Status|) : Choice<int,exn> -> int = function
 
 /// Acceptance tests illustrating the indended use of CallPolly wrt implementing flow control within an orchestration layer
 type Orchestration(output : Xunit.Abstractions.ITestOutputHelper) =
-    let log = LogHooks.createLogger output
+    let log, buffer = LogHooks.createLoggerWithCapture output
 
     let [<Fact>] ``Cutoff can be used to cap call time when upstreams misbehave`` () = async {
         let policy = Parser.parse log policy
@@ -139,4 +151,57 @@ type Orchestration(output : Xunit.Abstractions.ITestOutputHelper) =
         let sut = Sut(log, policy)
         let! Status res = sut.ApiTenSecondSla ThrowTimeout |> Async.Catch
         test <@ res = 504 @>
+    }
+
+    let [<Fact>] ``Circuit breaking base functionality`` () = async {
+        let policy = Parser.parse log policy
+        let sut = Sut(log, policy)
+        // 10 fails put it into circuit breaking mode - let's do 9 and the step carefully
+        let! res = List.replicate 9 (sut.ApiTenSecondSla ThrowTimeout |> Async.Catch) |> Async.Parallel
+        test <@ res |> Seq.forall (function Status s -> s = 504) @>
+
+        // Dump any logs we've seen to date
+        let callsToUpstreamThatIsTimingOut buffer = buffer |> List.filter (fun s -> s="B1") |> List.length
+        let logs = buffer.Take()
+        test <@ 9 = callsToUpstreamThatIsTimingOut logs @>
+
+        // The next one brings the minimum count up to the limit and hence will cause circuit breaking
+        let! Status res = sut.ApiTenSecondSla ThrowTimeout |> Async.Catch
+        test <@ res = 504 @>
+        let logs = buffer.Take()
+        test <@ 1 = callsToUpstreamThatIsTimingOut logs @>
+
+        // So any further attempts will not even attempt to execute
+        let! res = List.replicate 10 (sut.ApiTenSecondSla Succeed |> Async.Catch) |> Async.Parallel
+        test <@ res |> Seq.forall (function Status s -> s = 503) @>
+        // And we should see much reduced calls getting through
+        let logs = buffer.Take()
+        test <@ 1 >= callsToUpstreamThatIsTimingOut logs @>
+    }
+
+    let [<Fact>] ``Broken circuits can recover and be retriggered`` () = async {
+        let policy = Parser.parse log policy
+        let sut = Sut(log, policy)
+        // 10 fails put it into circuit breaking mode
+        let! res = List.replicate 10 (sut.ApiTenSecondSla ThrowTimeout |> Async.Catch) |> Async.Parallel
+        test <@ res |> Seq.forall (function Status s -> s = 504) @>
+
+        let callsToUpstreamThatIsTimingOut buffer = buffer |> List.filter (fun s -> s="B1") |> List.length
+        let logs = buffer.Take()
+        test <@ 10 = callsToUpstreamThatIsTimingOut logs @>
+        // Hold off until the 1s elapses so we're back into half-open mode
+        do! Async.Sleep (ms 1100)
+        // Let one succeed, validating it's closed again
+        let! Status res = sut.ApiTenSecondSla Succeed |> Async.Catch
+        test <@ 200 = res @>
+        // Feed in enough requests to meet the threshold
+        let! res = List.replicate 8 (sut.ApiTenSecondSla Succeed |> Async.Catch) |> Async.Parallel
+        test <@ res |> Seq.forall (function Status s -> s = 200) @>
+        // Because a) we're over the baseline traffic count and b) have a high error rate within the last 5 seconds since the closing
+        // three more fails will cause stuff to fail again
+        let! res = List.replicate 3 (sut.ApiTenSecondSla ThrowTimeout |> Async.Catch) |> Async.Parallel
+        test <@ res |> Seq.forall (function Status s -> s = 504) @>
+        // And even though the upstream is happy again, we fail
+        let! Status res = sut.ApiTenSecondSla Succeed |> Async.Catch
+        test <@ 503 = res @>
     }

--- a/tests/CallPolly.Acceptance/Tests.fs
+++ b/tests/CallPolly.Acceptance/Tests.fs
@@ -1,8 +1,0 @@
-﻿module CallPolly.Acceptance.Tests
-
-open System
-open Xunit
-
-//[<Fact>]
-//let ``My test`` () =
-//    Assert.True(true)


### PR DESCRIPTION
Adding acceptance tests showing high level flows and how they get mapped in terms of CallPolly primitives

- [x] Manual Isolation based on config for an upstream
- [x] Timeouts for calls wrapping upstreams that can't meet SLAs (yielding 503)
- [x] Timeouts for calls wrapping upstreams that timeout where we don't have a fallback (yielding 504)
- [x] Circuit breaking to isolate an an upstream that repeatedly times out
- [x] Bulkheads to shed load when too many requests arrive concurrently