### PR TITLE
App Integration: Provide segregated call log for tracing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
-    <VersionPrefix>0.0.4</VersionPrefix>
+    <VersionPrefix>0.0.5</VersionPrefix>
     <Authors>@jet @bartelink and contributors</Authors>
     <Company>Jet.com</Company>
     <Description>Apply systemwide resilience strategies consistently across subsystems, standing on Polly's shoulders</Description>


### PR DESCRIPTION
In order to be able to trap events specific to a given call in a call trace, need to be able to provide a specific log so they can be captured directly